### PR TITLE
Changing error types

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,15 +1,59 @@
 package nbnet
 
+type ErrorType uint8
+
+const (
+	ErrorTypeWriteTimeout	ErrorType	= iota
+	ErrorTypeReadTimeout
+	ErrorTypeWrite
+	ErrorTypeRead
+	ErrorTypeWarning
+	ErrorTypeFatal
+	ErrorTypeTotal
+)
+
+const (
+	stringErrorTypeWriteTimeout = "Write timeout"
+	stringErrorTypeReadTimeout = "Read timeout"
+	stringErrorTypeWrite = "Write"
+	stringErrorTypeRead = "Read"
+	stringErrorTypeWarning = "Warning"
+	stringErrorTypeFatal = "Fatal"
+	stringErrorTypeUnknown = "UKNOWN"
+)
+
+func (et ErrorType) String() string {
+	switch (et) {
+	case ErrorTypeWriteTimeout:
+		return stringErrorTypeWriteTimeout
+	case ErrorTypeReadTimeout:
+		return stringErrorTypeReadTimeout
+	case ErrorTypeWrite:
+		return stringErrorTypeWrite
+	case ErrorTypeRead:
+		return stringErrorTypeRead
+	case ErrorTypeWarning:
+		return stringErrorTypeWarning
+	case ErrorTypeFatal:
+		return stringErrorTypeFatal
+	}
+	
+	//default value
+	return stringErrorTypeUnknown
+}
+
 type Error struct {
+	etype	ErrorType
 	source  string
 	message string
 }
 
 func (e Error) Error() string {
-	return e.source + ": " + e.message
+	return e.source + "<" + e.etype.String() + ">: " + e.message
 }
 
 type ErrorEmbedded struct {
+	etype	ErrorType
 	source   string
 	message  string
 	embedded error
@@ -22,6 +66,6 @@ func (e ErrorEmbedded) Error() string {
 		result += e.embedded.Error() + "\n"
 	}
 
-	result += e.source + ": " + e.message
+	result += e.source + "<" + e.etype.String() + ">: " + e.message
 	return result
 }


### PR DESCRIPTION
The error types did not allow the receiver to distinguish between the
types of errors. As a result the main routine did not know the severity
of the error in the messaging routines and/or how to handle the error
(resending packet, ignoring, panic, etc.)
